### PR TITLE
Arg handling updates

### DIFF
--- a/searchtweets/result_stream.py
+++ b/searchtweets/result_stream.py
@@ -155,7 +155,7 @@ class ResultStream:
     session_request_counter = 0
 
     def __init__(self, endpoint, rule_payload, username=None, password=None,
-                 bearer_token=None, max_results=1000,
+                 bearer_token=None, max_results=500,
                  tweetify=True, max_requests=None, **kwargs):
 
         self.username = username

--- a/searchtweets/utils.py
+++ b/searchtweets/utils.py
@@ -29,7 +29,7 @@ __all__ = ["take", "partition", "merge_dicts", "write_result_stream",
 
 def take(n, iterable):
     """Return first n items of the iterable as a list.
-    Originaly found in the Python itertools documentation.
+    Originally found in the Python itertools documentation.
 
     Args:
         n (int): number of items to return


### PR DESCRIPTION
This PR fixes the problems underlying in #33. Arguments that were passed from configuration files (API args, not authentication args) were being overwritten by defaults in the command-line interface. The logic for parsing and creating the arguments that are sent to the API were updated as well as some  genuinely trivial fixes (spelling errors).

I'd appreciate a review!