### PR TITLE
Fix Issue #43 (incorrectly getting 401s) by explicitly specifying aut…

### DIFF
--- a/searchtweets/_version.py
+++ b/searchtweets/_version.py
@@ -2,4 +2,4 @@
 # Copyright 2018 Twitter, Inc.
 # Licensed under the MIT License
 # https://opensource.org/licenses/MIT
-VERSION = "1.7.1"
+VERSION = "1.7.2"

--- a/searchtweets/result_stream.py
+++ b/searchtweets/result_stream.py
@@ -27,6 +27,10 @@ from ._version import VERSION
 
 logger = logging.getLogger(__name__)
 
+class NoAuth(requests.auth.AuthBase):
+    def __call__(self, r):
+        return r
+
 
 def make_session(username=None, password=None, bearer_token=None):
     """Creates a Requests Session for use. Accepts a bearer token
@@ -119,7 +123,12 @@ def request(session, url, rule_payload, **kwargs):
     if isinstance(rule_payload, dict):
         rule_payload = json.dumps(rule_payload)
     logger.debug("sending request")
-    result = session.post(url, data=rule_payload, **kwargs)
+    result = session.post(
+        url,
+        auth=NoAuth(),  # TS: prevent requests library from using auth from last request
+        data=rule_payload,
+        **kwargs
+    )
     return result
 
 


### PR DESCRIPTION
…h param while using method of requests library and bump version

This is related to the issue filed here: https://github.com/twitterdev/search-tweets-python/issues/43

What I found after some debugging is that the python requests library is incorrectly sending the post request to the Twitter API using BASIC authorization (instead of BEARER). This is likely due to the HttpBasic auth set in the previous request from _generate_bearer_token(..) method. Fixed by explicitly specifying an auth parameter that does nothing essentially. Was able to resolve issue #43 with this change / successfully got results from Twitter apis vs the 401s.