### PR TITLE
Move `print_stream` check outside of loop

### DIFF
--- a/tools/search_tweets.py
+++ b/tools/search_tweets.py
@@ -198,8 +198,8 @@ def main():
     else:
         stream = rs.stream()
 
-    for tweet in stream:
-        if config_dict["print_stream"] is True:
+    if config_dict["print_stream"]:
+        for tweet in stream:
             print(json.dumps(tweet))
 
 


### PR DESCRIPTION
It seems unnecessary to do the same lookup on every single iteration when the result doesn't change.
