### PR TITLE
Check if 'meta' field is None. API V2 endpoint /2/tweets does not return 'meta' field.

### DIFF
--- a/searchtweets/result_stream.py
+++ b/searchtweets/result_stream.py
@@ -264,7 +264,8 @@ class ResultStream:
             resp = json.loads(resp.content.decode(resp.encoding))
 
             meta = resp.get("meta", None)
-            self.next_token = meta.get("next_token", None)
+            if meta is not None:
+                self.next_token = meta.get("next_token", None)
             self.current_tweets = resp.get("data", None)
 
         except:


### PR DESCRIPTION
Problem: API V2 endpoint /2/tweets does not return 'meta' field.

Proof-of-concept: the following code snippet returns _Error parsing content as JSON._

```
from searchtweets import collect_results

def search_tweet(twitter_id):
    search_args = {'bearer_token': 'YOUR_TOKEN',
                   'endpoint': 'https://api.twitter.com/2/tweets',
                   'tweetify': False
                   }

    query = {"ids":twitter_id}
    tweets = collect_results(query=query, result_stream_args=search_args)
    print(tweets)

search_tweet("1294741630013050887")
```

Solution: Check if 'meta' field is None. If so, we should not extract 'next_token'