### PR TITLE
Update utils.py read_config to use yaml.load_safe

### DIFF
--- a/searchtweets/_version.py
+++ b/searchtweets/_version.py
@@ -2,4 +2,4 @@
 # Copyright 2020 Twitter, Inc.
 # Licensed under the MIT License
 # https://opensource.org/licenses/MIT
-VERSION = "1.0.3"
+VERSION = "1.0.4"

--- a/searchtweets/utils.py
+++ b/searchtweets/utils.py
@@ -186,7 +186,7 @@ def read_config(filename):
 
     if file_type == "yaml":
         with open(os.path.expanduser(filename)) as f:
-            config_dict = yaml.load(f)
+            config_dict = yaml.safe_load(f)
 
         config_dict = merge_dicts(*[dict(config_dict[s]) for s
                                     in config_dict.keys()])


### PR DESCRIPTION
The usage of yaml.load is deprecated and was giving me warnings:

```
(venv) jordan@jlimon-ubuntu:~/Development/SoccerFeelz$ python3 fetch_tweets.py 
/home/jordan/Development/SoccerFeelz/venv/lib/python3.6/site-packages/searchtweets/utils.py:189: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  config_dict = yaml.load(f)
{'results_per_call': 100, 'max_tweets': 10000, 'tweet_fields': 'id,text,author_id,created_at,context_annotations,entities', 'user_fields': 'description,location,public_metrics', 'save_file': False, 'filename_prefix': 'soccer_tweets', 'results_per_file': 10000}
```
To remove the warning and match similar code in the repo I updated utils.py read_config to use yaml.load_safe.

