### PR TITLE
Docs and naming consistency for output format command line

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,13 +181,11 @@ Command-line options
                         stored.
    --no-print-stream     disable print streaming
    --print-stream        Print tweet stream to stdout
-   --output-options      Set output format: 
+   --output-format      Set output format: 
                          'r' Unmodified API Responses. (default).
                          'a' Atomic Tweets: Tweet objects with expansions inline.
                          'm' Message Stream: Tweets, Expansions, and Metadata
                          as a stream of messages.
-   --atomic              Output "Atomic" Tweet format. 
-                         Equivalent to setting --output-format 'a'.
    --extra-headers EXTRA_HEADERS
                         JSON-formatted str representing a dict of additional
                         HTTP request headers

--- a/scripts/poll_tweets.py
+++ b/scripts/poll_tweets.py
@@ -39,10 +39,10 @@ def parse_cmd_args():
 
     argparser.add_argument("--credential-file-key",
                            dest="credential_yaml_key",
-                           default=None,
+                           default="search_tweets_v2",
                            help=("the key in the credential file used "
                                  "for this session's credentials. "
-                                 "Defaults to search_tweets_api"))
+                                 "Defaults to search_tweets_v2"))
 
     argparser.add_argument("--env-overwrite",
                            dest="env_overwrite",
@@ -125,7 +125,7 @@ def parse_cmd_args():
 
     argparser.add_argument("--output-format",
                            dest="output_format",
-                           default=None,
+                           default="r",
                            help="""Set output format: 
                                    'r' Unmodified API Responses. (default).
                                    'a' Atomic Tweets: Tweet objects with expansions inline.

--- a/scripts/poll_tweets.py
+++ b/scripts/poll_tweets.py
@@ -127,9 +127,9 @@ def parse_cmd_args():
                            dest="output_format",
                            default="r",
                            help="""Set output format: 
-                                   'r' Unmodified API Responses. (default).
-                                   'a' Atomic Tweets: Tweet objects with expansions inline.
-                                   'm' Message Stream: Tweets, Expansions, and Metadata as a stream of messages.""")
+                                   'r' Unmodified API [R]esponses. (default).
+                                   'a' [A]tomic Tweets: Tweet objects with expansions inline.
+                                   'm' [M]essage stream: Tweets, expansions, and pagination metadata as a stream of messages.""")
 
     #client options.
     argparser.add_argument("--max-tweets", dest="max_tweets",

--- a/scripts/poll_tweets.py
+++ b/scripts/poll_tweets.py
@@ -123,6 +123,14 @@ def parse_cmd_args():
                            default=None,
                            help="""A comma-delimited list of Twitter Poll JSON attributes to include in endpoint responses. (API default:"id")""")
 
+    argparser.add_argument("--output-format",
+                           dest="output_format",
+                           default=None,
+                           help="""Set output format: 
+                                   'r' Unmodified API Responses. (default).
+                                   'a' Atomic Tweets: Tweet objects with expansions inline.
+                                   'm' Message Stream: Tweets, Expansions, and Metadata as a stream of messages.""")
+
     #client options.
     argparser.add_argument("--max-tweets", dest="max_tweets",
                            type=int,

--- a/scripts/search_tweets.py
+++ b/scripts/search_tweets.py
@@ -91,9 +91,9 @@ def parse_cmd_args():
                                 "'max_results' in the API")
 
     argparser.add_argument("--expansions",
-                       dest="expansions",
-                       default=None,
-                       help="""A comma-delimited list of expansions. Specified expansions results in full objects in the 'includes' response object.""")
+                           dest="expansions",
+                           default=None,
+                           help="""A comma-delimited list of expansions. Specified expansions results in full objects in the 'includes' response object.""")
 
     argparser.add_argument("--tweet-fields",
                            dest="tweet_fields",
@@ -122,7 +122,7 @@ def parse_cmd_args():
 
     argparser.add_argument("--output-format",
                            dest="output_format",
-                           default=None,
+                           default="r",
                            help="""Set output format: 
                                    'r' Unmodified API Responses. (default).
                                    'a' Atomic Tweets: Tweet objects with expansions inline.
@@ -160,8 +160,6 @@ def parse_cmd_args():
                            action="store_true",
                            default=True,
                            help="Print tweet stream to stdout")
-
-
 
     argparser.add_argument("--extra-headers",
                            dest="extra_headers",

--- a/scripts/search_tweets.py
+++ b/scripts/search_tweets.py
@@ -120,12 +120,6 @@ def parse_cmd_args():
                            default=None,
                            help="""A comma-delimited list of Twitter Poll JSON attributes to include in endpoint responses. (API default:"id")""")
 
-    argparser.add_argument("--atomic",
-                       dest="atomic",
-                       action="store_true",
-                       default=False,
-                       help="Inject 'includes' objects into Tweet objects.")
-
     argparser.add_argument("--output-options",
                            dest="output_options",
                            default=None,

--- a/scripts/search_tweets.py
+++ b/scripts/search_tweets.py
@@ -120,8 +120,8 @@ def parse_cmd_args():
                            default=None,
                            help="""A comma-delimited list of Twitter Poll JSON attributes to include in endpoint responses. (API default:"id")""")
 
-    argparser.add_argument("--output-options",
-                           dest="output_options",
+    argparser.add_argument("--output-format",
+                           dest="output_format",
                            default=None,
                            help="""Set output format: 
                                    'r' Unmodified API Responses. (default).

--- a/searchtweets/api_utils.py
+++ b/searchtweets/api_utils.py
@@ -187,6 +187,7 @@ def gen_params_from_config(config_dict):
              "bearer_token": config_dict.get("bearer_token"),
              "extra_headers_dict": config_dict.get("extra_headers_dict",None),
              "request_parameters": query,
+             "output_format": config_dict.get("output_format"),
              "results_per_file": intify(config_dict.get("results_per_file")),
              "max_tweets": intify(config_dict.get("max_tweets")),
              "max_pages": intify(config_dict.get("max_pages", None))}

--- a/searchtweets/api_utils.py
+++ b/searchtweets/api_utils.py
@@ -187,11 +187,10 @@ def gen_params_from_config(config_dict):
              "bearer_token": config_dict.get("bearer_token"),
              "extra_headers_dict": config_dict.get("extra_headers_dict",None),
              "request_parameters": query,
-             "output_format": config_dict.get("output_format"),
              "results_per_file": intify(config_dict.get("results_per_file")),
              "max_tweets": intify(config_dict.get("max_tweets")),
              "max_pages": intify(config_dict.get("max_pages", None)),
-             "output_option": config_dict.get("output_option")}
+             "output_format": config_dict.get("output_format")}
 
     return _dict
 

--- a/searchtweets/result_stream.py
+++ b/searchtweets/result_stream.py
@@ -170,7 +170,7 @@ class ResultStream:
     session_request_counter = 0
 
     def __init__(self, endpoint, request_parameters, bearer_token=None, extra_headers_dict=None, max_tweets=500,
-                 max_requests=None, atomic=False, output_options="r", **kwargs):
+                 max_requests=None, output_options="r", **kwargs):
 
         self.bearer_token = bearer_token
         self.extra_headers_dict = extra_headers_dict
@@ -193,8 +193,6 @@ class ResultStream:
         self.max_requests = (max_requests if max_requests is not None
                              else 10 ** 9)
         self.endpoint = endpoint
-        if atomic:
-            self.output_format = "a"
         self.output_format = output_options
 
     def formatted_output(self):

--- a/searchtweets/result_stream.py
+++ b/searchtweets/result_stream.py
@@ -170,7 +170,7 @@ class ResultStream:
     session_request_counter = 0
 
     def __init__(self, endpoint, request_parameters, bearer_token=None, extra_headers_dict=None, max_tweets=500,
-                 max_requests=None, output_options="r", **kwargs):
+                 max_requests=None, output_format="r", **kwargs):
 
         self.bearer_token = bearer_token
         self.extra_headers_dict = extra_headers_dict
@@ -193,7 +193,7 @@ class ResultStream:
         self.max_requests = (max_requests if max_requests is not None
                              else 10 ** 9)
         self.endpoint = endpoint
-        self.output_format = output_options
+        self.output_format = output_format
 
     def formatted_output(self):
 


### PR DESCRIPTION
I fixed the command line options for `--output-format` - i also overlooked the poll_tweets.py script earlier so i fixed that too.