### PR TITLE
Use utf-8 encoding for yaml files per default

### DIFF
--- a/searchtweets/_version.py
+++ b/searchtweets/_version.py
@@ -2,4 +2,4 @@
 # Copyright 2020 Twitter, Inc.
 # Licensed under the MIT License
 # https://opensource.org/licenses/MIT
-VERSION = "1.7.6"
+VERSION = "1.7.7"

--- a/searchtweets/utils.py
+++ b/searchtweets/utils.py
@@ -40,7 +40,7 @@ def take(n, iterable):
 
 def partition(iterable, chunk_size, pad_none=False):
     """adapted from Toolz. Breaks an iterable into n iterables up to the
-    certain chunk size, padding with Nones if availble.
+    certain chunk size, padding with Nones if available.
 
     Example:
         >>> from searchtweets.utils import partition
@@ -186,8 +186,8 @@ def read_config(filename):
     config = configparser.ConfigParser()
 
     if file_type == "yaml":
-        with open(os.path.expanduser(filename)) as f:
-            config_dict = yaml.load(f)
+        with open(os.path.expanduser(filename), encoding="utf-8") as f:
+            config_dict = yaml.safe_load(f)
 
         config_dict = merge_dicts(*[dict(config_dict[s]) for s
                                     in config_dict.keys()])


### PR DESCRIPTION
1. Added utf-8 encoding to be used for YAML files per default (this fixes issues with non-english characters -- such as "ä")
2. Replaced deprecated yaml.load with yaml.safe_load, [more info here](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)
3. Fixed typo.