### PR TITLE
Fix reading of environment variables

### DIFF
--- a/searchtweets/credentials.py
+++ b/searchtweets/credentials.py
@@ -58,7 +58,7 @@ def _load_env_credentials():
     for var in vars_:
         key = var.replace('SEARCHTWEETS_', '').lower()
         try:
-            parsed[key] = os.environ[key]
+            parsed[key] = os.environ[var]
         except KeyError:
             pass
     return parsed


### PR DESCRIPTION
Otherwise wrong environment variables without "SEARCHTWEETS_"-prefix are read.