### PR TITLE
Documentation typo fixed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -235,7 +235,7 @@ are used to control credential behavior from the command-line app.
 
 --------------
 
-Using the Comand Line Application
+Using the Command Line Application
 =================================
 
 The library includes an application, ``search_tweets.py``, that provides

--- a/build_sphinx_docs.sh
+++ b/build_sphinx_docs.sh
@@ -12,7 +12,7 @@ echo "Building documentation from $BRANCH_NAME"
 echo "checking out gh-pages"
 if ! git checkout gh-pages
 then
-  echo >&2 "checkout of gh-pages branch failed; please ensure you have local changes commited prior to running this script "
+  echo >&2 "checkout of gh-pages branch failed; please ensure you have local changes committed prior to running this script "
   echo "exiting"
   exit 1
 fi


### PR DESCRIPTION
Hello!

### Pull request overview
* Resolved two typos in `README.rst` and `build_sphinx_docs.sh`.

---

Note that `bash make_readme.sh` must be ran after this, as the README has been updated.
I purposefully didn't increment the version number.

- Tom Aarsen