### PR TITLE
Update search_tweets.py

### DIFF
--- a/tools/search_tweets.py
+++ b/tools/search_tweets.py
@@ -194,7 +194,7 @@ def main():
     if config_dict.get("filename_prefix") is not None:
         stream = write_result_stream(rs,
                                      filename_prefix=config_dict.get("filename_prefix"),
-                                     results_per_file=config_dict.get("results_per_file"))
+                                     results_per_file=stream_params.get("results_per_file"))
     else:
         stream = rs.stream()
 


### PR DESCRIPTION
fix a bug that cause the param "results_per_file" cannot be loaded as "int" when writing result stream